### PR TITLE
RetryBatchCommand causes overlapping of failed jobs when run concurrently with the same Batch ID

### DIFF
--- a/src/Illuminate/Queue/Console/RetryBatchCommand.php
+++ b/src/Illuminate/Queue/Console/RetryBatchCommand.php
@@ -45,7 +45,10 @@ class RetryBatchCommand extends Command
         $this->components->info("Pushing failed queue jobs of the batch [$id] back onto the queue.");
 
         foreach ($batch->failedJobIds as $failedJobId) {
-            $this->components->task($failedJobId, fn () => $this->callSilent('queue:retry', ['id' => $failedJobId]) == 0);
+            $this->components->task(
+                $failedJobId,
+                fn () => $this->callSilent('queue:retry', ['id' => $failedJobId, '--without-job-overlapping' => true]) == 0
+            );
         }
 
         $this->newLine();

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -66,7 +66,7 @@ class RetryCommand extends Command
 
                     $this->laravel['queue.failer']->forget($id);
                 } finally {
-                    if ($withoutJobOverlapping && $lock) {
+                    if ($lock) {
                         $lock->release();
                     }
                 }

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -49,19 +49,26 @@ class RetryCommand extends Command
         foreach ($ids as $id) {
             $job = $this->laravel['queue.failer']->find($id);
 
+            $lock = null;
+            if ($withoutJobOverlapping) {
+                $lock = $this->laravel['cache']->lock("retry:id:{$id}", 0, "retry:id:{$id}");
+            }
+
             if (is_null($job)) {
                 $this->components->error("Unable to find failed job with ID [{$id}].");
-            } elseif ($withoutJobOverlapping && !$this->laravel['cache']->lock("retry:id:{$id}")->get()) {
+            } elseif ($withoutJobOverlapping && $lock && ! $lock->get()) {
                 $this->components->error('The given failed job is already being executed.');
             } else {
-                $this->laravel['events']->dispatch(new JobRetryRequested($job));
+                try {
+                    $this->laravel['events']->dispatch(new JobRetryRequested($job));
 
-                $this->components->task($id, fn () => $this->retryJob($job));
+                    $this->components->task($id, fn () => $this->retryJob($job));
 
-                $this->laravel['queue.failer']->forget($id);
-
-                if ($withoutJobOverlapping) {
-                    $this->laravel['cache']->lock("retry:id:{$id}")->release();
+                    $this->laravel['queue.failer']->forget($id);
+                } finally {
+                    if ($withoutJobOverlapping && $lock) {
+                        $lock->release();
+                    }
                 }
             }
         }

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Queue;
 
 use Aws\DynamoDb\DynamoDbClient;
-use Illuminate\Cache\Repository as Cache;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Queue\Connectors\BeanstalkdConnector;
@@ -40,7 +39,6 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
         $this->registerWorker();
         $this->registerListener();
         $this->registerFailedJobServices();
-        $this->registerCache();
     }
 
     /**
@@ -325,18 +323,6 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
     }
 
     /**
-     * Register the cache.
-     *
-     * @return void
-     */
-    protected function registerCache()
-    {
-        $this->app->singleton('cache', function ($app) {
-            return $app->make(Cache::class);
-        });
-    }
-
-    /**
      * Get the services provided by the provider.
      *
      * @return array
@@ -349,7 +335,6 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
             'queue.failer',
             'queue.listener',
             'queue.worker',
-            'cache',
         ];
     }
 }

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Queue;
 
 use Aws\DynamoDb\DynamoDbClient;
+use Illuminate\Cache\Repository as Cache;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Queue\Connectors\BeanstalkdConnector;
@@ -39,6 +40,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
         $this->registerWorker();
         $this->registerListener();
         $this->registerFailedJobServices();
+        $this->registerCache();
     }
 
     /**
@@ -323,6 +325,18 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
     }
 
     /**
+     * Register the cache.
+     *
+     * @return void
+     */
+    protected function registerCache()
+    {
+        $this->app->singleton('cache', function ($app) {
+            return $app->make(Cache::class);
+        });
+    }
+
+    /**
      * Get the services provided by the provider.
      *
      * @return array
@@ -335,6 +349,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
             'queue.failer',
             'queue.listener',
             'queue.worker',
+            'cache',
         ];
     }
 }


### PR DESCRIPTION
Title: RetryBatchCommand causes overlapping of failed jobs when run concurrently with the same Batch ID

Description:
There is an issue in the job batching system that allows the same failed jobs to be added to the jobs table and executed multiple times (depending on the number of parallel processes of the RetryBatchCommand command for the same batch ID). This can result in a negative value for the number of pending jobs.

Steps to reproduce:

Create a batch with, for example, 1000 jobs.
Make the jobs fail (throw an exception)
Run the batch and verify that the value of failed_jobs in the pending_jobs table is 1000.
Make the jobs successful (remove the exception thrown)
Run several instances of the php artisan queue:retry-batch {id} command simultaneously or with a small time difference.
Check the job_batches table, and you will see that pending_jobs has a negative value. This indicates that some jobs have been executed multiple times by different processes.
Laravel version: 10.13.5

Proposed Solution:
Add the without-job-overlapping option to RetryCommand, which blocks the execution of a failed job using Cache lock, if such a job has already being executed
Add the execution of RetryCommand with this option to RetryBatchCommand